### PR TITLE
docker, merge keep timestamp, takes tags from fields

### DIFF
--- a/plugins/base/merge_flow.go
+++ b/plugins/base/merge_flow.go
@@ -82,8 +82,11 @@ func (mf *mergeFlow) Process(records []engine.Record, nextFunc engine.FlowNextFu
 	mf.table = remains
 
 	ret := []engine.Record{}
-	for _, r := range selected.Rows() {
-		ret = append(ret, engine.NewRecord(r...))
+	for _, k := range selected.Keys() {
+		row := selected.Get(k)
+		r := engine.NewRecord(row.Fields...)
+		r.Tags().Set(mf.joinTag, engine.NewValue(time.Unix(k, 0)))
+		ret = append(ret, r)
 	}
 	nextFunc(ret, nil)
 }

--- a/plugins/base/merge_flow_test.go
+++ b/plugins/base/merge_flow_test.go
@@ -1,11 +1,15 @@
 package base_test
 
 import (
+	"bytes"
+	"encoding/json"
+	"testing"
 	"time"
 
 	"github.com/OutOfBedlam/tine/engine"
 	_ "github.com/OutOfBedlam/tine/plugins/base"
 	_ "github.com/OutOfBedlam/tine/plugins/exec"
+	_ "github.com/OutOfBedlam/tine/plugins/psutil"
 )
 
 func ExampleMergeFlow() {
@@ -41,4 +45,60 @@ func ExampleMergeFlow() {
 	}
 	// Output:
 	// {"_ts":1721954797,"exec_stdout":"hello world","file_0":"a","file_1":"1"}
+}
+
+func TestExampleMergeFlow(t *testing.T) {
+	// This example demonstrates how to use the merge flow.
+	dsl := `
+	[[inlets.load]]
+		interval = "1s"
+		count = 3
+		loads = [1]
+	[[inlets.cpu]]
+		interval = "1s"
+		count = 3
+		percpu = false
+		total = true
+	[[flows.merge]]
+		wait_limit = "1.5s"
+	[[outlets.file]]
+		path = "-"
+		format = "json"
+	`
+	// Make the output time deterministic. so we can compare it.
+	// This line is not needed in production code.
+	seq := int64(0)
+	engine.Now = func() time.Time { seq++; return time.Unix(1721954797+(seq/4), 0) }
+	// Create a new engine.
+	buff := &bytes.Buffer{}
+	pipeline, err := engine.New(engine.WithConfig(dsl), engine.WithWriter(buff))
+	if err != nil {
+		panic(err)
+	}
+	// Run the engine.
+	if err := pipeline.Run(); err != nil {
+		panic(err)
+	}
+	pipeline.Stop()
+
+	dec := json.NewDecoder(buff)
+	for i := 0; i < 3; i++ {
+		rec := map[string]interface{}{}
+		if err := dec.Decode(&rec); err != nil {
+			t.Fatal(err)
+		}
+		if ts := rec["_ts"]; ts == nil {
+			t.Fatal("missing _ts")
+		} else {
+			if int64(ts.(float64)) != 1721954797+int64(i) {
+				t.Fatalf("unexpected _ts: %v", ts)
+			}
+		}
+		if rec["load_load1"] == nil {
+			t.Fatal("missing load_0")
+		}
+		if rec["cpu_total_percent"] == nil {
+			t.Fatal("missing cpu_total")
+		}
+	}
 }

--- a/plugins/influx/influx_outlet.toml
+++ b/plugins/influx/influx_outlet.toml
@@ -14,7 +14,7 @@
     tags = [
         {name="dc", value="us-east-1"},
         {name="env", value="prod"},
-        {name="_in"}
+        {name="#_in"}
     ]
 
     ## Write timeout, especially for the HTTP request

--- a/plugins/influx/influx_outlet_test.go
+++ b/plugins/influx/influx_outlet_test.go
@@ -3,6 +3,7 @@ package influx_test
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -50,6 +51,9 @@ func setupInfluxdb(ctx context.Context) (*influxdbContainer, error) {
 }
 
 func TestInfluxOutlet(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on windows")
+	}
 	ctx := context.Background()
 	influxC, err := setupInfluxdb(ctx)
 	if err != nil {

--- a/plugins/influx/influx_outlet_test.go
+++ b/plugins/influx/influx_outlet_test.go
@@ -3,7 +3,7 @@ package influx_test
 import (
 	"context"
 	"fmt"
-	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/OutOfBedlam/tine/engine"
@@ -49,12 +49,13 @@ func setupInfluxdb(ctx context.Context) (*influxdbContainer, error) {
 }
 
 func TestInfluxOutlet(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("skipping test on non-linux system")
-	}
 	ctx := context.Background()
 	influxC, err := setupInfluxdb(ctx)
 	if err != nil {
+		if strings.Contains(err.Error(), "Cannot connect to the Docker daemon") {
+			t.Skip("skipping test on non-docker system")
+		}
+		fmt.Printf("Error: %v %T\n", err, err)
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
- docker test skip if docker is not available
- merge yields records contains `_ts` tag
- outlets.influx takes care of tags from records fields